### PR TITLE
Remove new Python versions dekn#8387

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -121,58 +121,6 @@ api = "0.7"
     version = "3.8.16"
 
   [[metadata.dependencies]]
-    checksum = "sha256:58676489295f41a709123a3d5ebcf743db5ac028d0c034730e7355d50db4c13e"
-    cpe = "cpe:2.3:a:python:python:3.8.18:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.8.18?checksum=7c5df68bab1be81a52dea0cc2e2705ea00553b67107a301188383d7b57320b16&download_url=https://www.python.org/ftp/python/3.8.18/Python-3.8.18.tgz"
-    source = "https://www.python.org/ftp/python/3.8.18/Python-3.8.18.tgz"
-    source-checksum = "sha256:7c5df68bab1be81a52dea0cc2e2705ea00553b67107a301188383d7b57320b16"
-    stacks = ["io.buildpacks.stacks.jammy"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.8.18_linux_x64_jammy_58676489.tgz"
-    version = "3.8.18"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:bcc59a7fa44a4bdbe9bc3a2549cdf0be161fb1e954769cccaf9d43630543b50b"
-    cpe = "cpe:2.3:a:python:python:3.8.18:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.8.18?checksum=7c5df68bab1be81a52dea0cc2e2705ea00553b67107a301188383d7b57320b16&download_url=https://www.python.org/ftp/python/3.8.18/Python-3.8.18.tgz"
-    source = "https://www.python.org/ftp/python/3.8.18/Python-3.8.18.tgz"
-    source-checksum = "sha256:7c5df68bab1be81a52dea0cc2e2705ea00553b67107a301188383d7b57320b16"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.8.18_linux_x64_bionic_bcc59a7f.tgz"
-    version = "3.8.18"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:6fbd433e406ad34f7482a5cca59dae593893d2e082811de9a54f6babeb8dd376"
-    cpe = "cpe:2.3:a:python:python:3.8.19:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.8.19?checksum=c7fa55a36e5c7a19ec37d8f90f60a2197548908c9ac8b31e7c0dbffdd470eeac&download_url=https://www.python.org/ftp/python/3.8.19/Python-3.8.19.tgz"
-    source = "https://www.python.org/ftp/python/3.8.19/Python-3.8.19.tgz"
-    source-checksum = "sha256:c7fa55a36e5c7a19ec37d8f90f60a2197548908c9ac8b31e7c0dbffdd470eeac"
-    stacks = ["io.buildpacks.stacks.jammy"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.8.19_linux_x64_jammy_6fbd433e.tgz"
-    version = "3.8.19"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:47b20758b5e1d3b026b513e8ccc5e659f4a47066e28d7d8fc254fc03870f4f53"
-    cpe = "cpe:2.3:a:python:python:3.8.19::**:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.8.19?checksum=c7fa55a36e5c7a19ec37d8f90f60a2197548908c9ac8b31e7c0dbffdd470eeac&download_url=https://www.python.org/ftp/python/3.8.19/Python-3.8.19.tgz"
-    source = "https://www.python.org/ftp/python/3.8.19/Python-3.8.19.tgz"
-    source-checksum = "sha256:c7fa55a36e5c7a19ec37d8f90f60a2197548908c9ac8b31e7c0dbffdd470eeac"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.8.19_linux_x64_bionic_47b20758.tgz"
-    version = "3.8.19"
-
-  [[metadata.dependencies]]
     checksum = "sha256:702289c2c87e9c5050de0ae78a675dc98989eca2066b1a3750ad74c91f274e62"
     cpe = "cpe:2.3:a:python:python:3.9.15:*:*:*:*:*:*:*"
     id = "python"
@@ -223,58 +171,6 @@ api = "0.7"
     stacks = ["io.buildpacks.stacks.jammy"]
     uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.9.16_linux_x64_jammy_437b383f.tgz"
     version = "3.9.16"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:26e47486aaf03c1f4c9cb6a492f15f72f5b0d5145f8d1edf801dc3f241f503a6"
-    cpe = "cpe:2.3:a:python:python:3.9.18:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.9.18?checksum=504ce8cfd59addc04c22f590377c6be454ae7406cb1ebf6f5a350149225a9354&download_url=https://www.python.org/ftp/python/3.9.18/Python-3.9.18.tgz"
-    source = "https://www.python.org/ftp/python/3.9.18/Python-3.9.18.tgz"
-    source-checksum = "sha256:504ce8cfd59addc04c22f590377c6be454ae7406cb1ebf6f5a350149225a9354"
-    stacks = ["io.buildpacks.stacks.jammy"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.9.18_linux_x64_jammy_26e47486.tgz"
-    version = "3.9.18"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:688350eb4d393d2f26a3649d6aecafc9494083935c2dfa94e916b50736421968"
-    cpe = "cpe:2.3:a:python:python:3.9.18:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.9.18?checksum=504ce8cfd59addc04c22f590377c6be454ae7406cb1ebf6f5a350149225a9354&download_url=https://www.python.org/ftp/python/3.9.18/Python-3.9.18.tgz"
-    source = "https://www.python.org/ftp/python/3.9.18/Python-3.9.18.tgz"
-    source-checksum = "sha256:504ce8cfd59addc04c22f590377c6be454ae7406cb1ebf6f5a350149225a9354"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.9.18_linux_x64_bionic_688350eb.tgz"
-    version = "3.9.18"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:1f01367433e9ca604f2c522746de6e38e8244ce3b674366acf3fd31bd65f47c4"
-    cpe = "cpe:2.3:a:python:python:3.9.19:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.9.19?checksum=f5f9ec8088abca9e399c3b62fd8ef31dbd2e1472c0ccb35070d4d136821aaf71&download_url=https://www.python.org/ftp/python/3.9.19/Python-3.9.19.tgz"
-    source = "https://www.python.org/ftp/python/3.9.19/Python-3.9.19.tgz"
-    source-checksum = "sha256:f5f9ec8088abca9e399c3b62fd8ef31dbd2e1472c0ccb35070d4d136821aaf71"
-    stacks = ["io.buildpacks.stacks.jammy"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.9.19_linux_x64_jammy_1f013674.tgz"
-    version = "3.9.19"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:5e07b233e4d2a3e318230153e3af106112f6515de549756fe0a51f9fb6cfffd7"
-    cpe = "cpe:2.3:a:python:python:3.9.19:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.9.19?checksum=f5f9ec8088abca9e399c3b62fd8ef31dbd2e1472c0ccb35070d4d136821aaf71&download_url=https://www.python.org/ftp/python/3.9.19/Python-3.9.19.tgz"
-    source = "https://www.python.org/ftp/python/3.9.19/Python-3.9.19.tgz"
-    source-checksum = "sha256:f5f9ec8088abca9e399c3b62fd8ef31dbd2e1472c0ccb35070d4d136821aaf71"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.9.19_linux_x64_bionic_5e07b233.tgz"
-    version = "3.9.19"
 
   [[metadata.dependencies]]
     checksum = "sha256:32bd342a5aa435e6d8ef30a7a1428979f8f8fce975d8003bfd8cad394d16b75c"
@@ -329,58 +225,6 @@ api = "0.7"
     version = "3.10.11"
 
   [[metadata.dependencies]]
-    checksum = "sha256:8ba9a08177147d9f33a15370cb52552ca4af139c948cfb30a6ea1929fd71ec47"
-    cpe = "cpe:2.3:a:python:python:3.10.13:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.10.13?checksum=698ec55234c1363bd813b460ed53b0f108877c7a133d48bde9a50a1eb57b7e65&download_url=https://www.python.org/ftp/python/3.10.13/Python-3.10.13.tgz"
-    source = "https://www.python.org/ftp/python/3.10.13/Python-3.10.13.tgz"
-    source-checksum = "sha256:698ec55234c1363bd813b460ed53b0f108877c7a133d48bde9a50a1eb57b7e65"
-    stacks = ["io.buildpacks.stacks.jammy"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.10.13_linux_x64_jammy_8ba9a081.tgz"
-    version = "3.10.13"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:19a092d051de19e076a5fe051a611d3ba0c705993ff618f302041cde48fe16f7"
-    cpe = "cpe:2.3:a:python:python:3.10.13:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.10.13?checksum=698ec55234c1363bd813b460ed53b0f108877c7a133d48bde9a50a1eb57b7e65&download_url=https://www.python.org/ftp/python/3.10.13/Python-3.10.13.tgz"
-    source = "https://www.python.org/ftp/python/3.10.13/Python-3.10.13.tgz"
-    source-checksum = "sha256:698ec55234c1363bd813b460ed53b0f108877c7a133d48bde9a50a1eb57b7e65"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.10.13_linux_x64_bionic_19a092d0.tgz"
-    version = "3.10.13"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:9e7c333f13db7edd11ae4d5fa11805f33829738fecca426de98e0f74e5d97dee"
-    cpe = "cpe:2.3:a:python:python:3.10.14:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.10.14?checksum=cefea32d3be89c02436711c95a45c7f8e880105514b78680c14fe76f5709a0f6&download_url=https://www.python.org/ftp/python/3.10.14/Python-3.10.14.tgz"
-    source = "https://www.python.org/ftp/python/3.10.14/Python-3.10.14.tgz"
-    source-checksum = "sha256:cefea32d3be89c02436711c95a45c7f8e880105514b78680c14fe76f5709a0f6"
-    stacks = ["io.buildpacks.stacks.jammy"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.10.14_linux_x64_jammy_9e7c333f.tgz"
-    version = "3.10.14"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:5c7219ed547cab9b065a232a5b0de2ad43a725f2e06bcb5301654c7fa011a5b0"
-    cpe = "cpe:2.3:a:python:python:3.10.14:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.10.14?checksum=cefea32d3be89c02436711c95a45c7f8e880105514b78680c14fe76f5709a0f6&download_url=https://www.python.org/ftp/python/3.10.14/Python-3.10.14.tgz"
-    source = "https://www.python.org/ftp/python/3.10.14/Python-3.10.14.tgz"
-    source-checksum = "sha256:cefea32d3be89c02436711c95a45c7f8e880105514b78680c14fe76f5709a0f6"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.10.14_linux_x64_bionic_5c7219ed.tgz"
-    version = "3.10.14"
-
-  [[metadata.dependencies]]
     checksum = "sha256:2005aa05cfbe4a53445cec019240c091af37acf2b404b143cf5efc07d935485a"
     cpe = "cpe:2.3:a:python:python:3.11.2:*:*:*:*:*:*:*"
     id = "python"
@@ -433,71 +277,6 @@ api = "0.7"
     version = "3.11.3"
 
   [[metadata.dependencies]]
-    checksum = "sha256:569af6f3e797f3336da69c67272f51493493206adc39f90bce9410e7782e29eb"
-    cpe = "cpe:2.3:a:python:python:3.11.8:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.11.8?checksum=d3019a613b9e8761d260d9ebe3bd4df63976de30464e5c0189566e1ae3f61889&download_url=https://www.python.org/ftp/python/3.11.8/Python-3.11.8.tgz"
-    source = "https://www.python.org/ftp/python/3.11.8/Python-3.11.8.tgz"
-    source-checksum = "sha256:d3019a613b9e8761d260d9ebe3bd4df63976de30464e5c0189566e1ae3f61889"
-    stacks = ["io.buildpacks.stacks.jammy"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.11.8_linux_x64_jammy_569af6f3.tgz"
-    version = "3.11.8"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:b1b60a0153ce4fb9558ac63c88cb302c28e81e16659c2926dac1d568783b0fff"
-    cpe = "cpe:2.3:a:python:python:3.11.8:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.11.8?checksum=d3019a613b9e8761d260d9ebe3bd4df63976de30464e5c0189566e1ae3f61889&download_url=https://www.python.org/ftp/python/3.11.8/Python-3.11.8.tgz"
-    source = "https://www.python.org/ftp/python/3.11.8/Python-3.11.8.tgz"
-    source-checksum = "sha256:d3019a613b9e8761d260d9ebe3bd4df63976de30464e5c0189566e1ae3f61889"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.11.8_linux_x64_bionic_b1b60a01.tgz"
-    version = "3.11.8"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:09e182e9a83b4d3d34cf533bec46dac616e9ef9f5d31ea4640d76a7f655f6882"
-    cpe = "cpe:2.3:a:python:python:3.11.9:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.11.9?checksum=e7de3240a8bc2b1e1ba5c81bf943f06861ff494b69fda990ce2722a504c6153d&download_url=https://www.python.org/ftp/python/3.11.9/Python-3.11.9.tgz"
-    source = "https://www.python.org/ftp/python/3.11.9/Python-3.11.9.tgz"
-    source-checksum = "sha256:e7de3240a8bc2b1e1ba5c81bf943f06861ff494b69fda990ce2722a504c6153d"
-    stacks = ["io.buildpacks.stacks.jammy"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.11.9_linux_x64_jammy_09e182e9.tgz"
-    version = "3.11.9"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:c8bcebd67871868b52695ffde9f4e95d22d30a3044fc741e9b1f2ac028c4fbc5"
-    cpe = "cpe:2.3:a:python:python:3.11.9:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.11.9?checksum=e7de3240a8bc2b1e1ba5c81bf943f06861ff494b69fda990ce2722a504c6153d&download_url=https://www.python.org/ftp/python/3.11.9/Python-3.11.9.tgz"
-    source = "https://www.python.org/ftp/python/3.11.9/Python-3.11.9.tgz"
-    source-checksum = "sha256:e7de3240a8bc2b1e1ba5c81bf943f06861ff494b69fda990ce2722a504c6153d"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.11.9_linux_x64_bionic_c8bcebd6.tgz"
-    version = "3.11.9"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:877bd7130f769b99cfb6981f2c4f6b2bde1a882c8057ec903a31050f05683792"
-    cpe = "cpe:2.3:a:python:python:3.11.9:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.11.9?checksum=e7de3240a8bc2b1e1ba5c81bf943f06861ff494b69fda990ce2722a504c6153d&download_url=https://www.python.org/ftp/python/3.11.9/Python-3.11.9.tgz"
-    source = "https://www.python.org/ftp/python/3.11.9/Python-3.11.9.tgz"
-    source-checksum = "sha256:e7de3240a8bc2b1e1ba5c81bf943f06861ff494b69fda990ce2722a504c6153d"
-    stacks = ["io.buildpacks.stacks.noble"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.11.9_linux_x64_noble_877bd713.tgz"
-    version = "3.11.9"
-
-  [[metadata.dependencies]]
     checksum = "sha256:b87a3ef940234b0010b310d537a8bce351dc391fdc67f66873a2ef3ec0d4a840"
     cpe = "cpe:2.3:a:python:python:3.12.0:*:*:*:*:*:*:*"
     id = "python"
@@ -522,71 +301,6 @@ api = "0.7"
     stacks = ["io.buildpacks.stacks.jammy"]
     uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.12.0_linux_x64_jammy_9ae981ed.tgz"
     version = "3.12.0"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:aca1ad6266821d090f44466e8c01f2c41fb33da12d1c650d70ba555809abc55b"
-    cpe = "cpe:2.3:a:python:python:3.12.2:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.12.2?checksum=a7c4f6a9dc423d8c328003254ab0c9338b83037bd787d680826a5bf84308116e&download_url=https://www.python.org/ftp/python/3.12.2/Python-3.12.2.tgz"
-    source = "https://www.python.org/ftp/python/3.12.2/Python-3.12.2.tgz"
-    source-checksum = "sha256:a7c4f6a9dc423d8c328003254ab0c9338b83037bd787d680826a5bf84308116e"
-    stacks = ["io.buildpacks.stacks.jammy"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.12.2_linux_x64_jammy_aca1ad62.tgz"
-    version = "3.12.2"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:b1593a6d50a321ba99603dde97b277150f0b7c8a37dc351a194f14edc51ceeb7"
-    cpe = "cpe:2.3:a:python:python:3.12.2:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.12.2?checksum=a7c4f6a9dc423d8c328003254ab0c9338b83037bd787d680826a5bf84308116e&download_url=https://www.python.org/ftp/python/3.12.2/Python-3.12.2.tgz"
-    source = "https://www.python.org/ftp/python/3.12.2/Python-3.12.2.tgz"
-    source-checksum = "sha256:a7c4f6a9dc423d8c328003254ab0c9338b83037bd787d680826a5bf84308116e"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.12.2_linux_x64_bionic_b1593a6d.tgz"
-    version = "3.12.2"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:ea697edb14f9a72e03f88156bc4df2b943b9e03cfb94e3ba4299374e293d97fa"
-    cpe = "cpe:2.3:a:python:python:3.12.3:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.12.3?checksum=a6b9459f45a6ebbbc1af44f5762623fa355a0c87208ed417628b379d762dddb0&download_url=https://www.python.org/ftp/python/3.12.3/Python-3.12.3.tgz"
-    source = "https://www.python.org/ftp/python/3.12.3/Python-3.12.3.tgz"
-    source-checksum = "sha256:a6b9459f45a6ebbbc1af44f5762623fa355a0c87208ed417628b379d762dddb0"
-    stacks = ["io.buildpacks.stacks.jammy"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.12.3_linux_x64_jammy_ea697edb.tgz"
-    version = "3.12.3"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:4df494fbdde8cb56e38c53be94d49f4379a61304bd1c4b6c39a94018002f6da9"
-    cpe = "cpe:2.3:a:python:python:3.12.3:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.12.3?checksum=a6b9459f45a6ebbbc1af44f5762623fa355a0c87208ed417628b379d762dddb0&download_url=https://www.python.org/ftp/python/3.12.3/Python-3.12.3.tgz"
-    source = "https://www.python.org/ftp/python/3.12.3/Python-3.12.3.tgz"
-    source-checksum = "sha256:a6b9459f45a6ebbbc1af44f5762623fa355a0c87208ed417628b379d762dddb0"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.12.3_linux_x64_bionic_4df494fb.tgz"
-    version = "3.12.3"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:0910952cebf242edf92f5c53d19356c7f8bacf338713ab3c575a4b039eab95a9"
-    cpe = "cpe:2.3:a:python:python:3.12.3:*:*:*:*:*:*:*"
-    id = "python"
-    licenses = ["0BSD", "CNRI-Python-GPL-Compatible", "PSF-2.0"]
-    name = "Python"
-    purl = "pkg:generic/python@3.12.3?checksum=a6b9459f45a6ebbbc1af44f5762623fa355a0c87208ed417628b379d762dddb0&download_url=https://www.python.org/ftp/python/3.12.3/Python-3.12.3.tgz"
-    source = "https://www.python.org/ftp/python/3.12.3/Python-3.12.3.tgz"
-    source-checksum = "sha256:a6b9459f45a6ebbbc1af44f5762623fa355a0c87208ed417628b379d762dddb0"
-    stacks = ["io.buildpacks.stacks.noble"]
-    uri = "http://dash-app-resources.plotly-system.svc.cluster.local/packages/kpack-offline-files/python_3.12.3_linux_x64_noble_0910952c.tgz"
-    version = "3.12.3"
 
   [[metadata.dependency-constraints]]
     constraint = "3.6.*"


### PR DESCRIPTION
Remove new Python versions causing https://github.com/plotly/dekn/issues/8387

It seems new Python versions introduced a breaking change causing this:

```
-06-20T17:29:14.288Z: Processing /layers/paketo-buildpacks_pip/pip-source
2024-06-20T17:29:14.290Z:   Installing build dependencies: started
2024-06-20T17:29:15.726Z:   Installing build dependencies: finished with status 'error'
2024-06-20T17:29:15.796Z: failed to configure pip:
2024-06-20T17:29:15.797Z:   error: subprocess-exited-with-error
2024-06-20T17:29:15.797Z:   
2024-06-20T17:29:15.797Z:   × pip subprocess to install build dependencies did not run successfully.
2024-06-20T17:29:15.797Z:   │ exit code: 1
2024-06-20T17:29:15.797Z:   ╰─> [106 lines of output]
2024-06-20T17:29:15.797Z:       Looking in links: /layers/paketo-buildpacks_pip/pip-source
2024-06-20T17:29:15.797Z:       Processing /layers/paketo-buildpacks_pip/pip-source/setuptools-57.4.0.tar.gz
2024-06-20T17:29:15.797Z:         Installing build dependencies: started
2024-06-20T17:29:15.797Z:         Installing build dependencies: finished with status 'error'
2024-06-20T17:29:15.797Z:         error: subprocess-exited-with-error
2024-06-20T17:29:15.797Z:       
2024-06-20T17:29:15.797Z:         × pip subprocess to install build dependencies did not run successfully.
2024-06-20T17:29:15.797Z:         │ exit code: 1
2024-06-20T17:29:15.797Z:         ╰─> [87 lines of output]
2024-06-20T17:29:15.797Z:             Looking in links: /layers/paketo-buildpacks_pip/pip-source
2024-06-20T17:29:15.797Z:             Processing /layers/paketo-buildpacks_pip/pip-source/wheel-0.37.0.tar.gz
2024-06-20T17:29:15.797Z:               Installing build dependencies: started
2024-06-20T17:29:15.797Z:               Installing build dependencies: finished with status 'error'
2024-06-20T17:29:15.797Z:               error: subprocess-exited-with-error
2024-06-20T17:29:15.797Z:       
2024-06-20T17:29:15.797Z:               × pip subprocess to install build dependencies did not run successfully.
2024-06-20T17:29:15.797Z:               │ exit code: 2
2024-06-20T17:29:15.797Z:               ╰─> [68 lines of output]
2024-06-20T17:29:15.797Z:                   Looking in links: /layers/paketo-buildpacks_pip/pip-source
2024-06-20T17:29:15.797Z:                   Processing /layers/paketo-buildpacks_pip/pip-source/setuptools-57.4.0.tar.gz
2024-06-20T17:29:15.797Z:                   ERROR: Exception:
2024-06-20T17:29:15.797Z:                   Traceback (most recent call last):
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_internal/cli/base_command.py", line 180, in exc_logging_wrapper
2024-06-20T17:29:15.797Z:                       status = run_func(*args)
2024-06-20T17:29:15.797Z:                                ^^^^^^^^^^^^^^^
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_internal/cli/req_command.py", line 245, in wrapper
2024-06-20T17:29:15.797Z:                       return func(self, options, args)
2024-06-20T17:29:15.797Z:                              ^^^^^^^^^^^^^^^^^^^^^^^^^
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_internal/commands/install.py", line 377, in run
2024-06-20T17:29:15.797Z:                       requirement_set = resolver.resolve(
2024-06-20T17:29:15.797Z:                                         ^^^^^^^^^^^^^^^^^
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_internal/resolution/resolvelib/resolver.py", line 95, in resolve
2024-06-20T17:29:15.797Z:                       result = self._result = resolver.resolve(
2024-06-20T17:29:15.797Z:                                               ^^^^^^^^^^^^^^^^^
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_vendor/resolvelib/resolvers.py", line 546, in resolve
2024-06-20T17:29:15.797Z:                       state = resolution.resolve(requirements, max_rounds=max_rounds)
2024-06-20T17:29:15.797Z:                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_vendor/resolvelib/resolvers.py", line 397, in resolve
2024-06-20T17:29:15.797Z:                       self._add_to_criteria(self.state.criteria, r, parent=None)
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_vendor/resolvelib/resolvers.py", line 173, in _add_to_criteria
2024-06-20T17:29:15.797Z:                       if not criterion.candidates:
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_vendor/resolvelib/structs.py", line 156, in __bool__
2024-06-20T17:29:15.797Z:                       return bool(self._sequence)
2024-06-20T17:29:15.797Z:                              ^^^^^^^^^^^^^^^^^^^^
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_internal/resolution/resolvelib/found_candidates.py", line 155, in __bool__
2024-06-20T17:29:15.797Z:                       return any(self)
2024-06-20T17:29:15.797Z:                              ^^^^^^^^^
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_internal/resolution/resolvelib/found_candidates.py", line 143, in <genexpr>
2024-06-20T17:29:15.797Z:                       return (c for c in iterator if id(c) not in self._incompatible_ids)
2024-06-20T17:29:15.797Z:                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_internal/resolution/resolvelib/found_candidates.py", line 47, in _iter_built
2024-06-20T17:29:15.797Z:                       candidate = func()
2024-06-20T17:29:15.797Z:                                   ^^^^^^
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 182, in _make_candidate_from_link
2024-06-20T17:29:15.797Z:                       base: Optional[BaseCandidate] = self._make_base_candidate_from_link(
2024-06-20T17:29:15.797Z:                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 228, in _make_base_candidate_from_link
2024-06-20T17:29:15.797Z:                       self._link_candidate_cache[link] = LinkCandidate(
2024-06-20T17:29:15.797Z:                                                          ^^^^^^^^^^^^^^
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 290, in __init__
2024-06-20T17:29:15.797Z:                       super().__init__(
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 156, in __init__
2024-06-20T17:29:15.797Z:                       self.dist = self._prepare()
2024-06-20T17:29:15.797Z:                                   ^^^^^^^^^^^^^^^
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 222, in _prepare
2024-06-20T17:29:15.797Z:                       dist = self._prepare_distribution()
2024-06-20T17:29:15.797Z:                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 301, in _prepare_distribution
2024-06-20T17:29:15.797Z:                       return preparer.prepare_linked_requirement(self._ireq, parallel_builds=True)
2024-06-20T17:29:15.797Z:                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_internal/operations/prepare.py", line 525, in prepare_linked_requirement
2024-06-20T17:29:15.797Z:                       return self._prepare_linked_requirement(req, parallel_builds)
2024-06-20T17:29:15.797Z:                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_internal/operations/prepare.py", line 640, in _prepare_linked_requirement
2024-06-20T17:29:15.797Z:                       dist = _get_prepared_distribution(
2024-06-20T17:29:15.797Z:                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_internal/operations/prepare.py", line 70, in _get_prepared_distribution
2024-06-20T17:29:15.797Z:                       with build_tracker.track(req, tracker_id):
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/contextlib.py", line 137, in __enter__
2024-06-20T17:29:15.797Z:                       return next(self.gen)
2024-06-20T17:29:15.797Z:                              ^^^^^^^^^^^^^^
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_internal/operations/build/build_tracker.py", line 137, in track
2024-06-20T17:29:15.797Z:                       self.add(req, tracker_id)
2024-06-20T17:29:15.797Z:                     File "/layers/paketo-buildpacks_cpython/cpython/lib/python3.11/site-packages/pip/_internal/operations/build/build_tracker.py", line 103, in add
2024-06-20T17:29:15.797Z:                       raise LookupError(message)
2024-06-20T17:29:15.797Z:                   LookupError: file:///layers/paketo-buildpacks_pip/pip-source/setuptools-57.4.0.tar.gz is already being built: setuptools from file:///layers/paketo-buildpacks_pip/pip-source/setuptools-57.4.0.tar.gz
2024-06-20T17:29:15.797Z:                   [end of output]
2024-06-20T17:29:15.797Z:       
2024-06-20T17:29:15.797Z:               note: This error originates from a subprocess, and is likely not a problem with pip.
2024-06-20T17:29:15.797Z:             error: subprocess-exited-with-error
2024-06-20T17:29:15.797Z:       
2024-06-20T17:29:15.797Z:             × pip subprocess to install build dependencies did not run successfully.
2024-06-20T17:29:15.797Z:             │ exit code: 2
2024-06-20T17:29:15.797Z:             ╰─> See above for output.
2024-06-20T17:29:15.797Z:       
2024-06-20T17:29:15.797Z:             note: This error originates from a subprocess, and is likely not a problem with pip.
2024-06-20T17:29:15.797Z:             [end of output]
2024-06-20T17:29:15.797Z:       
2024-06-20T17:29:15.797Z:         note: This error originates from a subprocess, and is likely not a problem with pip.
2024-06-20T17:29:15.797Z:       error: subprocess-exited-with-error
2024-06-20T17:29:15.797Z:       
2024-06-20T17:29:15.797Z:       × pip subprocess to install build dependencies did not run successfully.
2024-06-20T17:29:15.797Z:       │ exit code: 1
2024-06-20T17:29:15.797Z:       ╰─> See above for output.
2024-06-20T17:29:15.797Z:       
2024-06-20T17:29:15.797Z:       note: This error originates from a subprocess, and is likely not a problem with pip.
2024-06-20T17:29:15.797Z:       [end of output]
2024-06-20T17:29:15.797Z:   
```

I tested with 3.11.8 and 3.11.9: it fails.
With 3.11.3: it works.

